### PR TITLE
Change dynamic abbrev shortcut

### DIFF
--- a/scripts/dynamic-abbrev.rkt
+++ b/scripts/dynamic-abbrev.rkt
@@ -42,8 +42,8 @@
 (define-script dabbrev
   #:label "D&ynamic completion"
   #:menu-path ("Re&factor")
-  #:shortcut #\t
-  #:shortcut-prefix (ctl shift)
+  #:shortcut #\/
+  #:shortcut-prefix (alt)
   (λ (s #:editor ed) 
     (define pos (send ed get-end-position)) 
     (define left  (get-word ed pos -1))


### PR DESCRIPTION
This PR is a suggestion to change the shortcut for `dynamic-abbrev`.  The current shortcut appears to be `c:s:t` (control shift t).  This conflicts with a shortcut that is built-in(?) to DrRacket for "Reopen Closed Tab" (related issue [here](https://github.com/racket/drracket/issues/508)) -- at least it conflicts in my environment.

The suggested alternative shortcut is `a:/` (alt slash) to match what it is in Emacs (which I guess is the origin of the feature idea?).  AFAICT, `a:/` does not conflict with any existing shortcut -- but this was only examined via the dialog which appears in DrRacket via `Edit` -> `Keybindings` -> `Show Active Keybindings`.